### PR TITLE
Allow 3rd parties to supply requesting IP address

### DIFF
--- a/includes/utils/location.php
+++ b/includes/utils/location.php
@@ -492,7 +492,7 @@ class Location {
 
 		$ips = array_map( 'trim', explode( ',', $found ) );
 
-		return array_pop( $ips );
+		return apply_filters( 'groundhogg/location/get_real_ip', array_pop( $ips ) );
 	}
 
 


### PR DESCRIPTION
The current built-in method to obtain visitor IP address in Groundhogg is a bit limited and taking `REMOTE_ADDR` by default, in our hosting for example, doesn't work. We'd like to have the option to ensure that the correct visitor IP address is always available to GH.

The filter/hook name used is just an educated guess at what you might like to use: `groundhogg/location/get_real_ip`

Many thanks!