### PR TITLE
Fix return value signature documentation for get_current_tab_cap() in tabbed-admin-page

### DIFF
--- a/admin/tabbed-admin-page.php
+++ b/admin/tabbed-admin-page.php
@@ -69,7 +69,7 @@ abstract class Tabbed_Admin_Page extends Admin_Page {
 	/**
 	 * Retrieves the cap for the current tab
 	 *
-	 * @return bool
+	 * @return string
 	 */
 	public function get_current_tab_cap() {
 


### PR DESCRIPTION
get_current_tab_cap()'s return value is passed as first parameter of current_user_can() while rendering Groundhogg's Log > various tabs contents, which requires a string instead of bool https://developer.wordpress.org/reference/functions/current_user_can/

Example filter for legacy :
```
if ( ! function_exists( 'disallow_groundhogg_non_admin_events_manage_tab' ) ) {
	//
	function disallow_groundhogg_non_admin_events_manage_tab( $cap, $tab, $action ) {
		return $cap == 'view_events' && $tab == 'manage' && $action == 'view' ? 'disallowed_cap' : $cap;
	}
	add_filter( 'groundhogg/admin/get_current_tab_cap', 'disallow_groundhogg_non_admin_events_manage_tab', 10, 3 );

}
```